### PR TITLE
Fix the homepage title rendering a raw Blade directive

### DIFF
--- a/resources/lang/en/home.php
+++ b/resources/lang/en/home.php
@@ -2,8 +2,7 @@
 
 return [
     "title" => [
-        "exclamation" => "!",
-        "welcome_to" => "Welcome to",
+        "welcome" => "Welcome to :brand!",
         "sub" => "The return of two great communities, TopRed and KingdomHills, through a whole new Open Source infrastructure. Sharing and Innovation is our way to go!",
         "version" => "Version :version",
 

--- a/resources/lang/fr/home.php
+++ b/resources/lang/fr/home.php
@@ -2,8 +2,7 @@
 
 return [
     "title" => [
-        "exclamation" => " !",
-        "welcome_to" => "Bienvenue sur",
+        "welcome" => "Bienvenue sur :brand !",
         "sub" => "Le retour de deux grandes communautés, TopRed et KingdomHills, à travers une toute nouvelle infrastructure open source. Partage et innovation seront notre crédo !",
         "version" => "Version :version",
 

--- a/resources/views/components/home/header.blade.php
+++ b/resources/views/components/home/header.blade.php
@@ -23,7 +23,7 @@ $nbPlayers = DiscordHelper::getPlayersConnected();
         </div>
 
         <div class="flex flex-col justify-center sm:w-1/2">
-            <h1>@lang('home.title.welcome_to') <span class="text-6xl">RedCraft{{ __('home.title.exclamation') }}</span></h1>
+            <h1>{!! __('home.title.welcome', ['brand' => '<span class="text-6xl">RedCraft</span>']) !!}</h1>
             <p>@lang('home.title.sub')</p>
             <b>@lang('home.title.version', ['version' => $versions])</b>
         </div>

--- a/resources/views/components/home/header.blade.php
+++ b/resources/views/components/home/header.blade.php
@@ -23,7 +23,7 @@ $nbPlayers = DiscordHelper::getPlayersConnected();
         </div>
 
         <div class="flex flex-col justify-center sm:w-1/2">
-            <h1>@lang('home.title.welcome_to') <span class="text-6xl">RedCraft@lang('home.title.exclamation')</span></h1>
+            <h1>@lang('home.title.welcome_to') <span class="text-6xl">RedCraft{{ __('home.title.exclamation') }}</span></h1>
             <p>@lang('home.title.sub')</p>
             <b>@lang('home.title.version', ['version' => $versions])</b>
         </div>


### PR DESCRIPTION
The homepage title was rendering `RedCraft@lang('home.title.exclamation')`
literally. My fault, and it went out in #89.

Blade will not compile a directive when a word character sits directly before
the `@`. The guard exists so an address written in a template survives
compilation, and `RedCraft@lang` trips it for exactly the same reason
`someone@example.com` does. Nothing warns about it, it just emits the text.

Two commits: the fix, then the thing that should have been done first.

The title was built from two keys with the brand name hardcoded between them,
which is the only reason the exclamation mark needed a key of its own, to land
on the right side of the name. French ended up with a key containing nothing but
a space and a bang.

It is one string now with the brand as a placeholder:

    "welcome" => "Welcome to :brand!"
    "welcome" => "Bienvenue sur :brand !"

A translator sees the whole sentence and can put the name where their language
wants it, and the French space before the bang is part of the sentence rather
than a separate key.

Checked by running both locales through the translator: English gives
"Welcome to RedCraft!" and French "Bienvenue sur RedCraft !", with the span on
the brand intact in both.
