### PR TITLE
Stop the page stylesheet overriding the class Alpine toggles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,11 @@ jobs:
           node-version: "22"
           cache: npm
 
+      # Builds first because one of the tests loads the compiled stylesheets in
+      # the order the page emits them, to check a page file has not started
+      # overriding a utility class that Alpine toggles.
       - name: Run front end tests
         run: |
           npm ci
+          npm run build
           npm test

--- a/resources/js/__tests__/stylesheet-order.test.js
+++ b/resources/js/__tests__/stylesheet-order.test.js
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { expect, test } from 'vitest';
+
+const DIR = 'public/build/assets';
+const find = (re) => (existsSync(DIR) ? readdirSync(DIR).find((f) => re.test(f)) : undefined);
+
+// Page stylesheets used to be linked above the layout, so a utility class in
+// the main bundle beat anything a page file declared. They are pushed into the
+// head after it now, which reverses that. Anything a page file declares that
+// Alpine also toggles will therefore win and the toggle silently stops working.
+// That is how all three code of conduct panels ended up visible at once.
+test('a panel carrying opacity-0 actually computes to transparent', () => {
+    const app = find(/^app-.*\.css$/);
+    const rules = find(/^rules-.*\.css$/);
+    expect(app, 'run npm run build before the tests').toBeDefined();
+    expect(rules).toBeDefined();
+
+    document.head.innerHTML =
+        `<style>${readFileSync(`${DIR}/${app}`, 'utf8')}</style>` +
+        `<style>${readFileSync(`${DIR}/${rules}`, 'utf8')}</style>`;
+    document.body.innerHTML =
+        `<div class="code-conduct-details" id="shown">a</div>
+         <div class="code-conduct-details opacity-0" id="hidden">b</div>`;
+
+    expect(getComputedStyle(document.getElementById('shown')).opacity).toBe('1');
+    expect(getComputedStyle(document.getElementById('hidden')).opacity).toBe('0');
+});

--- a/resources/lang/en/rules.php
+++ b/resources/lang/en/rules.php
@@ -73,7 +73,7 @@ return [
             ],
             '3' => [
                 'title' => 'Creative Build',
-                '1' => 'The rules of the Creative Redstone section apply here.',
+                '1' => 'The rules of the Minecraft General section apply here.',
             ],
             '4' => [
                 'title' => 'Survival',

--- a/resources/lang/fr/rules.php
+++ b/resources/lang/fr/rules.php
@@ -73,7 +73,7 @@ return [
             ],
             '3' => [
                 'title' => 'Créatif Build',
-                '1' => "Les règles de la section Créatif Redstone s'appliquent ici.",
+                '1' => "Les règles de la section Général de Minecraft s'appliquent ici.",
             ],
             '4' => [
                 'title' => 'Survie',

--- a/resources/sass/pages/rules.scss
+++ b/resources/sass/pages/rules.scss
@@ -22,5 +22,11 @@
 }
 
 .code-conduct-details {
-    @apply opacity-100 duration-150;
+    // No opacity-100 here. Alpine toggles opacity-0 on these panels, and both
+    // are single class selectors, so whichever stylesheet loads last wins.
+    // This file used to be linked above the layout's own stylesheet, so the
+    // utility won; it is pushed into the head after it now, so declaring
+    // opacity here would beat opacity-0 and show all three panels at once.
+    // They are opaque by default anyway, so there is nothing to declare.
+    @apply duration-150;
 }


### PR DESCRIPTION
The code of conduct panels render on top of each other. Not Alpine, the cascade, and my regression from the Mix to Vite change.

The panels are stacked deliberately and only opacity separates them: Alpine puts `opacity-0` on the inactive two. `rules.scss` also declared `opacity-100` on the same element. Equal specificity, so source order decides.

Mix linked the page stylesheet on line 1 of the view, above the layout, so it lost to the utility and the toggle worked. Pushing it into the styles stack put it after the layout's tag, so it started winning and pinned every panel to opacity 1.

```
old css, page stylesheet first  -> opacity 0  (correct, how Mix emitted it)
old css, page stylesheet second -> opacity 1  (the bug)
new css, page stylesheet second -> opacity 0  (fixed)
```

Dropping the declaration rather than reordering the tags: elements are opaque by default so it was never needed, and a page file should not race the utilities.

The test loads both compiled stylesheets in page order and asserts a panel with `opacity-0` computes to transparent. It fails against the old css with `expected '1' to be '0'`, so it would have caught this. CI builds before running the front end tests now, since the test reads the compiled output.