### PR TITLE
Bring the rules page back in line with the Notion

### DIFF
--- a/resources/lang/en/rules.php
+++ b/resources/lang/en/rules.php
@@ -49,16 +49,16 @@ return [
             '1' => [
                 'title' => 'General',
                 '1' => "Griefing, i.e. destroying another player's building without his consent, setting traps that attack another player or stealing items.",
-                '2' => 'The use of cheats, i.e. software, mods or the exploitation of bugs present in the game that can provide a significant advantage, to the detriment of other players.',
-                '3' => 'The use of more than one Minecraft account per player.',
-                '4' => 'The use of software or mods intended to recover/download partially or entirely the map of the server.',
-                '5' => [
+                '1_note' => "Being a member of another player's plot does not mean you may modify their land without their consent.",
+                '2' => 'The use of cheats, i.e. software, mods or the exploitation of bugs present in the game that can provide an unfair advantage over other players.',
+                '3' => 'The use of software or mods intended to recover/download partially or entirely the map of the server.',
+                '4' => [
                     'title' => 'Continued possession of a modified item',
                     '1' => 'Giving the player an advantage over the others (effect, potion, etc...).',
                     '2' => 'Having a name or description that violates General rule 1.3.',
                     '3' => [
                         'title' => 'Giving access to commands normally out of reach of the player.',
-                        'note' => 'If a player receives or finds an altered item corresponding to rule 1.5 above, he/she must immediately notify the staff, give the item to a staff member and then dispose of it.',
+                        'note' => 'If a player receives or finds an altered item as described above, he/she must immediately notify the staff, give the item to a staff member and then dispose of it.',
                     ],
                 ],
             ],
@@ -77,6 +77,8 @@ return [
             ],
             '4' => [
                 'title' => 'Survival',
+                'intro' => "The Vanilla Survival server aims to be lax on rules, to encourage a free play experience. Sanctions are applied without warning, however, so use your common sense, and if a rule is unclear do not hesitate to contact a staff member.",
+                'intro_sanctions' => "Sanctions on the survival server are strict. As a rule the first is a one month ban and the second is permanent. For a deliberate breach the permanent ban is preferred as the first sanction. Sanctions are applied case by case and the staff has the final say.",
                 '1' => 'Collaboration: To contribute to a public project, you must first refer to the player responsible for the construction. If you wish to undertake a large project, make sure not to disturb other players who are building nearby. When in doubt, ask.',
                 '2' => 'All farms must be able to be deactivated to avoid lag.',
                 '3' => [
@@ -84,9 +86,10 @@ return [
                     'description' => 'such as bugs and glitches that provide an unfair advantage over other players is prohibited.',
                     'table' => [
                         'headers' => ['Allowed', 'Not Allowed'],
-                        'columns' => [['Duplication of TNT. Example: tunnel machine, quarry', 'FreeCam, to look around above ground', 'Autoclicker', ''], ['Duplication of chest, shulker and all other containers', 'Mining with Xray, or using FreeCam to see underground', 'Having a Mod giving an advantage on PVP, for example Kill Aura or Kill Reach', 'Automatic mining. Example: Baritone']],
+                        'columns' => [['Duplication of TNT. Example: tunnel machine, quarry', 'FreeCam, to look around above ground', 'Autoclicker', ''], ['Duplication of chests, shulkers and all other containers', 'Mining with Xray, or using FreeCam to see underground', 'Having a Mod giving an advantage on PVP, for example Kill Aura or Kill Reach', 'Automatic mining. Example: Baritone']],
                     ],
 
+                    'note_scope' => "The table below gives examples of what is and is not allowed. It is not exhaustive, use it to get a sense of what goes on the server, and contact a staff member if you are unsure.",
                     'note' => 'Modified clients (mods) are unofficial mechanics.',
                 ],
                 '4' => [
@@ -95,7 +98,8 @@ return [
                     'note' => 'Before modifying the terrain or borrowing someone\'s belongings, make sure you have their agreement. When in doubt, ask!',
                 ],
                 '5' => 'Stealing the belongings or resources of another player is forbidden.',
-                '6' => 'Unwanted PVP is prohibited. Or any other form of harassment.',
+                '6' => 'Unwanted PVP is prohibited.',
+                '7' => "The use of more than one Minecraft account per player is forbidden on this server.",
             ],
         ],
     ],

--- a/resources/lang/fr/rules.php
+++ b/resources/lang/fr/rules.php
@@ -49,16 +49,16 @@ return [
             '1' => [
                 'title' => 'Général',
                 '1' => "Le grief, c'est-à-dire la destruction d'une construction d'un autre joueur sans son accord, la mise en place de pièges visant un autre joueur ou encore le vol d'items.",
-                '2' => "L'utilisation de cheats, c'est-à-dire des logiciels ou des mods, ou l'exploitation de bugs présents dans le jeu et pouvant procurer un avantage conséquent par rapport aux autres joueurs.",
-                '3' => "L'utilisation de plus d'un compte Minecraft par joueur.",
-                '4' => "L'utilisation de logiciels ou de mods destinés à récupérer ou télécharger partiellement ou entièrement la map du serveur.",
-                '5' => [
+                '1_note' => "Être membre du plot d'un autre joueur ne signifie pas que vous pouvez modifier son terrain sans son accord.",
+                '2' => "L'utilisation de cheats, c'est-à-dire des logiciels ou des mods, ou l'exploitation de bugs présents dans le jeu et pouvant procurer un avantage déloyal par rapport aux autres joueurs.",
+                '3' => "L'utilisation de logiciels ou de mods destinés à récupérer ou télécharger partiellement ou entièrement la map du serveur.",
+                '4' => [
                     'title' => "La possession continue d'un item modifié",
                     '1' => 'Donnant au joueur un avantage par rapport aux autres (effet, potion).',
                     '2' => 'Dont le nom ou la description enfreint la règle 1.3 de la section Général.',
                     '3' => [
                         'title' => "Donnant accès à des commandes auxquelles le joueur n'a normalement pas accès.",
-                        'note' => "si un joueur reçoit ou trouve un item modifié tel que décrit par la règle 1.5 ci-dessus, il doit immédiatement avertir le staff, donner l'item à un membre du staff et s'en débarrasser par la suite.",
+                        'note' => "si un joueur reçoit ou trouve un item modifié tel que décrit ci-dessus, il doit immédiatement avertir le staff, donner l'item à un membre du staff et s'en débarrasser par la suite.'item à un membre du staff et s'en débarrasser par la suite.",
                     ],
                 ],
             ],
@@ -77,6 +77,8 @@ return [
             ],
             '4' => [
                 'title' => 'Survie',
+                'intro' => "Le serveur Survie Vanilla a pour but d'être laxiste sur les règles afin de favoriser une expérience de jeu libre. Les sanctions sont cependant appliquées sans préavis, alors utilisez votre bon sens, et si une règle est floue n'hésitez pas à contacter un membre du staff.",
+                'intro_sanctions' => "Les sanctions sur le serveur survie sont strictes. En général la première est un ban d'un mois et la deuxième un ban définitif. En cas de violation intentionnelle, le ban définitif est privilégié comme première sanction. L'application se fait au cas par cas et le staff a le choix final.",
                 '1' => 'Collaboration : Pour contribuer à un projet public, il faut d\'abord se référer au joueur responsable de la construction. Si vous souhaitez entreprendre un grand projet, assurez-vous de ne pas déranger d\'autres joueurs qui construisent à proximité. Dans le doute, demandez.',
                 '2' => 'Toutes les fermes doivent pouvoir être désactivées afin d\'éviter le lag.',
                 '3' => [
@@ -85,9 +87,10 @@ return [
 
                     'table' => [
                         'headers' => ['Autorisé', 'Interdit'],
-                        'columns' => [['Duplication de TNT. Exemple : machine à tunnel, quarry', 'FreeCam, pour regarder autour de vous en surface', 'Autoclicker', ''], ['Duplication de coffre, de shulker et de tout autres conteneurs', 'Minage avec Xray, ou utilisation de la FreeCam pour voir sous terre', 'Avoir un Mod donnant un avantage sur le PVP, par exemple Kill Aura ou Kill Reach', 'Minage automatique. Par exemple : Baritone']],
+                        'columns' => [['Duplication de TNT. Exemple : machine à tunnel, quarry', 'FreeCam, pour regarder autour de vous en surface', 'Autoclicker', ''], ['Duplication de coffres, de shulkers et de tous les autres conteneurs', 'Minage avec Xray, ou utilisation de la FreeCam pour voir sous terre', 'Avoir un Mod donnant un avantage sur le PVP, par exemple Kill Aura ou Kill Reach', 'Minage automatique. Par exemple : Baritone']],
                     ],
 
+                    'note_scope' => "Le tableau suivant donne des exemples de situations autorisées et non autorisées. Cette liste n'est pas exhaustive, utilisez-la pour vous faire une idée de ce qui est autorisé ou non sur le serveur, et contactez un membre du staff si vous n'êtes pas sûr.",
                     'note' => 'Les clients modifiés (mods) sont des mécaniques non officielles.',
                 ],
                 '4' => [
@@ -96,7 +99,8 @@ return [
                     'note' => 'Avant de modifier le terrain ou d\'emprunter les affaires d\'une personne, assurez-vous d\'avoir son accord. Dans le doute, demandez !',
                 ],
                 '5' => 'Voler les affaires ou les ressources d\'un autre joueur est interdit.',
-                '6' => "Le PVP non consenti est interdit. Ou tout autre form d'harcèlement.",
+                '6' => "Le PVP non consenti est interdit.",
+                '7' => "L'utilisation de plus d'un compte Minecraft par joueur est interdite sur ce serveur.",
             ],
         ],
     ],

--- a/resources/views/components/rules/recursive-rule.blade.php
+++ b/resources/views/components/rules/recursive-rule.blade.php
@@ -47,7 +47,13 @@
             @include('components/rules/recursive-rule', ['rules' => $rule, 'level' => $level + 1])
         @else
             {{--  @dump('Not recursive ' . $key)  --}}
-            @if ($key == 'note')
+            @if (\Illuminate\Support\Str::startsWith($key, 'intro'))
+                {{-- Prose that introduces a section rather than a numbered rule.
+                     No label, and outside the ol so it is not counted. --}}
+                <div class="mb-4 text-secondary whitespace-pre-line">{{ $rule }}</div>
+            @elseif (\Illuminate\Support\Str::startsWith($key, 'note'))
+                {{-- Any key beginning with note renders as one, so a section can
+                     carry more than a single one. Array keys are unique. --}}
                 <div class="text-secondary">@lang('rules.rules.note'){{ $rule }}</div>
             @else
                 <li>{{ $rule }}</li>

--- a/resources/views/rules.blade.php
+++ b/resources/views/rules.blade.php
@@ -9,10 +9,23 @@
             __('rules.rules.general.2.title') => [__('rules.rules.general.2.1'), __('rules.rules.general.2.2')],
         ],
         __('rules.rules.minecraft.title') => [
-            __('rules.rules.minecraft.1.title') => [__('rules.rules.minecraft.1.1'), __('rules.rules.minecraft.1.2'), __('rules.rules.minecraft.1.3'), __('rules.rules.minecraft.1.4'), __('rules.rules.minecraft.1.5.title') => [__('rules.rules.minecraft.1.5.1'), __('rules.rules.minecraft.1.5.2'), __('rules.rules.minecraft.1.5.3.title'), 'note' => __('rules.rules.minecraft.1.5.3.note')]],
+            __('rules.rules.minecraft.1.title') => [
+                __('rules.rules.minecraft.1.1'),
+                'note' => __('rules.rules.minecraft.1.1_note'),
+                __('rules.rules.minecraft.1.2'),
+                __('rules.rules.minecraft.1.3'),
+                __('rules.rules.minecraft.1.4.title') => [
+                    __('rules.rules.minecraft.1.4.1'),
+                    __('rules.rules.minecraft.1.4.2'),
+                    __('rules.rules.minecraft.1.4.3.title'),
+                    'note' => __('rules.rules.minecraft.1.4.3.note'),
+                ],
+            ],
             __('rules.rules.minecraft.2.title') => [__('rules.rules.minecraft.2.1.title'), 'note' => __('rules.rules.minecraft.2.1.note'), __('rules.rules.minecraft.2.2'), __('rules.rules.minecraft.2.3')],
             __('rules.rules.minecraft.3.title') => [__('rules.rules.minecraft.3.1')],
             __('rules.rules.minecraft.4.title') => [
+                'intro' => __('rules.rules.minecraft.4.intro'),
+                'intro_sanctions' => __('rules.rules.minecraft.4.intro_sanctions'),
                 __('rules.rules.minecraft.4.1'),
                 __('rules.rules.minecraft.4.2'),
                 __('rules.rules.minecraft.4.3.title') => [
@@ -37,6 +50,7 @@
                             ]
                         ]
                     ],
+                    'note_scope' => __('rules.rules.minecraft.4.3.note_scope'),
                     'note' => __('rules.rules.minecraft.4.3.note'),
                 ],
                 __('rules.rules.minecraft.4.4.title') => [
@@ -45,6 +59,7 @@
                 ],
                 __('rules.rules.minecraft.4.5'),
                 __('rules.rules.minecraft.4.6'),
+                __('rules.rules.minecraft.4.7'),
             ],
         ],
     ];


### PR DESCRIPTION
The page had drifted from the Notion it publishes, in both directions.

## Added, from the Notion

- Being a member of someone's plot is not permission to edit their land
- The survival preamble: deliberately lax, but **sanctions land without warning**
- **The sanctions themselves**: a month for a first offence, permanent for a second, permanent immediately when the breach was deliberate, case by case
- The mechanics table **is not exhaustive** — without that line it reads as the complete list

The last two matter most. Players were being sanctioned under a policy the public page never stated.

## Changed

**One account per player** stays but moves to survival and is worded for that server, since there are reasonable uses for a second account elsewhere. That rule sitting in the general section is also what pushed every later number down by one, which is how the cross reference to `2.1.4` ended up pointing at nothing. Numbers are now contiguous again.

**The harassment clause on the pvp rule is gone.** General already forbids harassment across the whole network; repeating it under survival only narrowed it.

**Cheating is measured against an unfair advantage**, not a significant one. Different tests, and the Notion asks for the first.

Two French errors: `tout autre form` and `de tout autres conteneurs`.

## Renderer

Two small additions. Any key beginning with `note` renders as one, so a section can carry more than a single note, which `4.3` now needs. Keys beginning with `intro` render as prose outside the `ol`, so a preamble is not presented as rule number one.

## Checked

Built the image and rendered the page: all 55 keys the blade references resolve, en and fr are at 67 keys each with no divergence, the grief note sits under the grief rule, survival opens with two prose paragraphs, and the table carries both notes.

## Still open

Section 4 is written as sentences and imperatives while sections 1 to 3 are noun phrases completing "the following behaviours are prohibited". So "All farms must be able to be deactivated" currently reads as a prohibition. That is an editorial pass on either section 4 or the whole page, and wants a decision rather than a guess.