### PR TITLE
Stop running a second Alpine alongside Livewire's

### DIFF
--- a/resources/js/__tests__/app.test.js
+++ b/resources/js/__tests__/app.test.js
@@ -4,37 +4,48 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 
 beforeEach(() => {
-    // Alpine starts once per module instance, so the entry point has to be
-    // re-evaluated for each test rather than served from the module cache.
     vi.resetModules();
     delete window.Alpine;
     document.body.innerHTML = '';
 });
 
-// The bug this guards against: app.js assigned window.Alpine and then imported
-// alpineFunctions.js, which reached for that global. ES imports are hoisted, so
-// the import ran first, threw on an undefined Alpine, and stopped the whole
-// bundle. Nothing surfaced as an error, Alpine just never started.
-test('importing the entry point does not throw, and Alpine ends up on window', async () => {
+// Livewire 3 ships and starts its own Alpine. This entry point must register
+// against that one and must not create a second, or Alpine reports "Detected
+// multiple instances" and @entangle stops working, which is what left the
+// contact form rendering as an empty box.
+test('the entry point imports without throwing', async () => {
     await expect(import('../app.js')).resolves.toBeDefined();
-    expect(window.Alpine).toBeDefined();
 });
 
-test('alpineFunctions registers its magic without relying on a global', async () => {
+test('it does not start an Alpine of its own', async () => {
     await import('../app.js');
-    expect(typeof window.Alpine.magic).toBe('function');
-    expect(window.Alpine.version).toBeTruthy();
+    expect(window.Alpine, 'app.js must not create a second Alpine').toBeUndefined();
 });
 
-// The regression was invisible in markup terms: Alpine never processed the DOM,
-// so everything meant to start hidden rendered at once. This asserts Alpine is
-// actually driving the document rather than merely being present on window.
-test('Alpine processes x-show, so hidden panels stay hidden', async () => {
-    document.body.innerHTML = `
-        <div x-data="{ open: false }">
-            <p id="panel" x-show="open">details</p>
-        </div>`;
+test('on alpine:init it registers the plugin and the clipboard magic', async () => {
+    const plugin = vi.fn();
+    const magic = vi.fn();
     await import('../app.js');
-    await new Promise((r) => setTimeout(r, 50));
-    expect(document.getElementById('panel').style.display).toBe('none');
+
+    window.Alpine = { plugin, magic };
+    document.dispatchEvent(new Event('alpine:init'));
+
+    // Not an exact count: each import in this file leaves its alpine:init
+    // listener on the shared jsdom document, so earlier tests add to the tally.
+    expect(plugin, 'intersect plugin not registered').toHaveBeenCalled();
+    expect(magic).toHaveBeenCalledWith('clipboard', expect.any(Function));
+});
+
+test('the clipboard magic writes to the clipboard', async () => {
+    const writeText = vi.fn();
+    Object.defineProperty(window.navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const magic = vi.fn();
+    await import('../app.js');
+
+    window.Alpine = { plugin: vi.fn(), magic };
+    document.dispatchEvent(new Event('alpine:init'));
+
+    const factory = magic.mock.calls.find(([name]) => name === 'clipboard')[1];
+    factory()('hello');
+    expect(writeText).toHaveBeenCalledWith('hello');
 });

--- a/resources/js/alpineFunctions.js
+++ b/resources/js/alpineFunctions.js
@@ -1,10 +1,7 @@
-import Alpine from 'alpinejs';
-
-// Imports its own reference rather than reaching for a global. Under Mix this
-// file was pulled in with require(), which runs inline, so window.Alpine was
-// already set by the time it ran. ES imports are hoisted and evaluated before
-// the importing module's body, so relying on the global here left Alpine
-// undefined and took the whole bundle down with it.
-Alpine.magic('clipboard', () => {
-    return subject => navigator.clipboard.writeText(subject)
+// Registered against Livewire's Alpine on alpine:init rather than against an
+// imported instance, since this app no longer creates one of its own.
+document.addEventListener('alpine:init', () => {
+    window.Alpine.magic('clipboard', () => {
+        return subject => navigator.clipboard.writeText(subject)
+    })
 })

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,13 @@
-import Alpine from 'alpinejs';
 import intersect from '@alpinejs/intersect';
 import './alpineFunctions.js';
 
-window.Alpine = Alpine;
-Alpine.plugin(intersect);
-Alpine.start();
+// No Alpine import and no Alpine.start() here on purpose. Livewire 3 ships its
+// own Alpine and starts it, and @livewireScripts is on every layout, so
+// creating a second instance gives "Detected multiple instances of Alpine
+// running" and breaks @entangle, which is what left the contact form blank.
+//
+// alpine:init fires before Livewire starts Alpine, which is the window in which
+// plugins have to be registered.
+document.addEventListener('alpine:init', () => {
+    window.Alpine.plugin(intersect);
+});

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -14,10 +14,15 @@
         @vite(['resources/sass/app.scss', 'resources/js/app.js'])
 
         <!-- Scripts -->
+        @livewireStyles
     </head>
     <body>
         <div class="font-sans text-gray-900 antialiased">
             {{ $slot }}
         </div>
+
+        {{-- Alpine comes from Livewire now, so every layout has to load it or
+             the pages using this one lose their interactivity entirely. --}}
+        @livewireScripts
     </body>
 </html>


### PR DESCRIPTION
The contact form renders as an empty box in production.

Livewire 3 ships Alpine and starts it. This app was importing and starting its own on top, so the console carries **`Detected multiple instances of Alpine running`**, and the form's `x-data` reaches through `window.Livewire.find(...).entangle(...)` — which needs *Livewire's* Alpine. It evaluated against the wrong instance and threw, so the heading rendered and the form did not.

The `livewire:upgrade` command prints this as a manual step, and I did not do it when I ran it. This is the rest of that migration.

## What changed

Alpine comes from Livewire alone now. The intersect plugin and the clipboard magic register on `alpine:init`, which fires before Livewire starts it. **Our bundle goes from 53 kB to 1 kB**, since it was carrying a second copy of Alpine.

`guest.blade.php` gains `@livewireStyles` and `@livewireScripts`. It had neither, and **18 views use it**, so removing our Alpine without this would have left those pages with none at all.

## Checked

Built the image, served the page, and loaded it with both scripts under jsdom:

```
multiple-Alpine warning: none      (was: present)
window.Alpine present  : true
window.Livewire present: true
<form> found           : true
buttons in the form    : 5
```

Tests updated to match: the entry point must import cleanly, must **not** create an Alpine of its own, and must register the plugin and magic when `alpine:init` fires.