### PR TITLE
Ask for the Discord username people actually have

### DIFF
--- a/app/Livewire/ContactForm.php
+++ b/app/Livewire/ContactForm.php
@@ -46,7 +46,9 @@ class ContactForm extends Component
         return [
             'username' => !$this->fromPlayer ? '' : 'required|min:4',
             'email' => $this->fromPlayer ? '' : 'required|email',
-            'discord_username' => 'nullable|regex:/^(?:[a-zA-Z0-9_.]{2,32}|.{3,32}#[0-9]{4})$/',
+            // Discord retired the #0000 discriminator in 2023 and migrated every user
+            // account, so only the current username shape is worth accepting.
+            'discord_username' => 'nullable|regex:/^[a-zA-Z0-9._]{2,32}$/',
             'subject' => 'required|min:4',
             'message' => 'required|min:30|max:' . self::MESSAGE_MAX_LENGTH,
         ];

--- a/resources/lang/en/contact.php
+++ b/resources/lang/en/contact.php
@@ -10,7 +10,7 @@ return [
         "other" => "Other",
         "back" => "Back",
         "minecraft_pseudo" => "Minecraft username",
-        "discord_id" => "Discord ID (username#0000)",
+        "discord_id" => "Discord username",
         "email" => "Email address",
         "subject" => "Subject",
         "message" => "Message",
@@ -23,7 +23,7 @@ return [
         "messages" => [
             "username_required" => "A Minecraft username is required.",
             "username_min" => "This Minecraft username is too short.",
-            "discord_username_regex" => "Enter your Discord username, for example someone_123, or the older someone#0000 format if your account still uses one.",
+            "discord_username_regex" => "A Discord username is 2 to 32 characters, using letters, numbers, dots and underscores.",
             "email_required" => "An email address is required.",
             "email_email" => "The email address is invalid.",
             "subject_required" => "A subject is required.",

--- a/resources/lang/fr/contact.php
+++ b/resources/lang/fr/contact.php
@@ -10,7 +10,7 @@ return [
         "other" => "Autre",
         "back" => "Retour",
         "minecraft_pseudo" => "Pseudo Minecraft",
-        "discord_id" => "Identifiant Discord (Nom#0000)",
+        "discord_id" => "Pseudo Discord",
         "email" => "Adresse email",
         "subject" => "Sujet",
         "message" => "Message",
@@ -23,7 +23,7 @@ return [
         "messages" => [
             "username_required" => "Le pseudo Minecraft est requis.",
             "username_min" => "Le pseudo Minecraft est trop court.",
-            "discord_username_regex" => "Entrez votre pseudo Discord, par exemple pseudo_123, ou l'ancien format pseudo#0000 si votre compte l'utilise encore.",
+            "discord_username_regex" => "Un pseudo Discord fait de 2 à 32 caractères, avec des lettres, des chiffres, des points et des tirets bas.",
             "email_required" => "L'adresse email est requise.",
             "email_email" => "L'adresse email n'est pas valide.",
             "subject_required" => "Le sujet est requis.",


### PR DESCRIPTION
The field still reads **`Discord ID (username#0000)`**. That is the placeholder, the part a visitor actually reads, and it shipped unchanged in #97 because that change only touched the validation message underneath it.

Discord retired discriminators in 2023 and migrated every user account, so the legacy branch in the pattern was matching a format nobody can enter any more. Dropped:

```diff
- 'nullable|regex:/^(?:[a-zA-Z0-9_.]{2,32}|.{3,32}#[0-9]{4})$/'
+ 'nullable|regex:/^[a-zA-Z0-9._]{2,32}$/'
```

Placeholders become `Discord username` / `Pseudo Discord`, and the messages describe the rule rather than a template.

Verified on the running local build: zero occurrences of `#0000` in the served page, in either language.