### PR TITLE
Bring the map and the stats onto the site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ EXPOSE 8000
 # affects generated urls, so it stays true in the environment.
 ENTRYPOINT ["php", "artisan", "octane:start", \
             "--server=frankenphp", \
+            "--caddyfile=/app/docker/Caddyfile", \
             "--host=0.0.0.0", \
             "--port=8000", \
             "--admin-port=2019", \

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,83 @@
+# Octane's own FrankenPHP Caddyfile with one addition, kept placeholder for
+# placeholder so everything Octane injects through the environment still works.
+#
+# The addition is the /stats proxy. Plan is a separate application on its own
+# host, and its dashboard picks its language from localStorage with no query
+# parameter or Accept-Language path. Serving it from this origin means the site
+# and the dashboard share that storage, so the language can be set from the
+# session without modifying anything inside Plan.
+#
+# Caddy proxies it in Go. Routing a megabyte of dashboard bundle through PHP
+# would be the wrong tool.
+{
+	{$CADDY_GLOBAL_OPTIONS}
+
+	admin {$CADDY_SERVER_ADMIN_HOST}:{$CADDY_SERVER_ADMIN_PORT}
+
+	frankenphp {
+		worker {
+			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php"
+			{$CADDY_SERVER_WORKER_DIRECTIVE}
+			{$CADDY_SERVER_WATCH_DIRECTIVES}
+		}
+	}
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$CADDY_SERVER_SERVER_NAME} {
+	log {
+		level {$CADDY_SERVER_LOG_LEVEL}
+
+		# Redact the authorization query parameter that can be set by Mercure...
+		format filter {
+			wrap {$CADDY_SERVER_LOGGER}
+			fields {
+				uri query {
+					replace authorization REDACTED
+				}
+			}
+		}
+	}
+
+	# Plan, served from this origin so it shares localStorage with the site.
+	#
+	# handle_path strips the /stats prefix, so Plan still answers from its own
+	# root. Its bundle then asks for /static, /v1, /manifest.json and
+	# /pageExtensionApi.js as absolute paths, which is why those are proxied
+	# too. The site claims none of them, its own assets are under /build.
+	handle_path /stats/* {
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+	}
+
+	handle /static/* {
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+	}
+
+	handle /v1/* {
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+	}
+
+	handle /auth/* {
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+	}
+
+	handle /pageExtensionApi.js {
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+	}
+
+	route {
+		root * "{$APP_PUBLIC_PATH}"
+		encode zstd br gzip
+
+		# Mercure configuration is injected here...
+		{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+		php_server {
+			index frankenphp-worker.php
+			try_files {path} frankenphp-worker.php
+			# Required for the public/storage/ directory...
+			resolve_root_symlink
+		}
+	}
+}

--- a/resources/lang/en/maps.php
+++ b/resources/lang/en/maps.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'title' => 'Maps',
+    'section_title' => 'Explore the world',
+    'description' => 'A live render of the RedCraft worlds, updated as the servers run. Pick a world from the menu inside the map.',
+    'fullscreen' => 'Open the map fullscreen',
+    'fallback' => 'The map could not load here. :link',
+    'fallback_link' => 'Open it in a new tab',
+];

--- a/resources/lang/en/stats.php
+++ b/resources/lang/en/stats.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'title' => 'Stats',
+    'section_title' => 'Server statistics',
+    'description' => 'Player activity across the network, updated live. Browse sessions, playtime and per-player history.',
+    'fullscreen' => 'Open the statistics fullscreen',
+];

--- a/resources/lang/fr/maps.php
+++ b/resources/lang/fr/maps.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'title' => 'Cartes',
+    'section_title' => 'Explorer le monde',
+    'description' => 'Un rendu en direct des mondes de RedCraft, mis à jour au fil des serveurs. Choisissez un monde dans le menu de la carte.',
+    'fullscreen' => 'Ouvrir la carte en plein écran',
+    'fallback' => 'La carte n\'a pas pu se charger ici. :link',
+    'fallback_link' => 'Ouvrir dans un nouvel onglet',
+];

--- a/resources/lang/fr/stats.php
+++ b/resources/lang/fr/stats.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'title' => 'Statistiques',
+    'section_title' => 'Statistiques du serveur',
+    'description' => 'L\'activité des joueurs sur le réseau, mise à jour en direct. Parcourez les sessions, le temps de jeu et l\'historique de chaque joueur.',
+    'fullscreen' => 'Ouvrir les statistiques en plein écran',
+];

--- a/resources/views/maps.blade.php
+++ b/resources/views/maps.blade.php
@@ -1,0 +1,42 @@
+@php
+    $mapUrl = config('services.bluemap-url');
+@endphp
+
+<x-app-layout>
+
+    <x-page-header section-title="{{ __('maps.title') }}" />
+
+    {{-- overflow-x-clip so the full bleed map below cannot introduce a
+         horizontal scrollbar. clip rather than hidden, since hidden would make
+         this a scroll container and break the sticky navbar above it. --}}
+    <x-section section-title="{{ __('maps.section_title') }}" bg="bg-base-100" text="text-light"
+        wave-bg="fill-base-100" wave-id="3" class="overflow-x-clip">
+
+        <p class="mb-6 text-center">{{ __('maps.description') }}</p>
+
+        {{-- BlueMap ships its own world picker and controls, so this only has to
+             give it room and stay out of the way.
+
+             The section constrains its content to screen-lg, which is not much
+             of a map. This steps outside that and takes 80% of the viewport,
+             recentring itself, so the map is wide while the text above it still
+             reads at a sensible measure. --}}
+        <div class="relative left-1/2 -translate-x-1/2 overflow-hidden rounded-lg shadow-lg bg-base-200"
+             style="width: 80vw; height: min(80vh, 1100px); min-height: 24rem;">
+            <iframe
+                src="{{ $mapUrl }}"
+                title="{{ __('maps.title') }}"
+                loading="lazy"
+                class="absolute inset-0 w-full h-full border-0"
+                allowfullscreen>
+            </iframe>
+        </div>
+
+        <div class="mt-6 text-center">
+            <a href="{{ $mapUrl }}" target="_blank" rel="noopener"
+               class="btn btn-primary">{{ __('maps.fullscreen') }}</a>
+        </div>
+
+    </x-section>
+
+</x-app-layout>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -12,14 +12,14 @@
             'link' => 'vote',
         ],
         [
-            'type' => 'blank',
+            'type' => 'route',
             'name' => __('nav.links.5'),
-            'link' => config('services.bluemap-url'),
+            'link' => 'maps',
         ],
         [
-            'type' => 'blank',
+            'type' => 'route',
             'name' => __('nav.links.3'),
-            'link' => config('services.plan-url'),
+            'link' => 'stats',
         ],
         [
             'type' => 'route',

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -1,0 +1,61 @@
+@php
+    // Plan is proxied from this origin by the Caddyfile the container runs, so
+    // it is same-origin with the site rather than a different host.
+    $statsPath = '/stats/network';
+
+    // Plan reads its language from localStorage and offers no query parameter
+    // or Accept-Language path. Sharing an origin is what lets the site write
+    // that value, so this needs nothing changed inside Plan itself.
+    $planLocale = strtoupper(app()->getLocale());
+@endphp
+
+<x-app-layout>
+
+    <x-page-header section-title="{{ __('stats.title') }}" />
+
+    <x-section section-title="{{ __('stats.section_title') }}" bg="bg-base-100" text="text-light"
+        wave-bg="fill-base-100" wave-id="3" class="overflow-x-clip">
+
+        <p class="mb-6 text-center">{{ __('stats.description') }}</p>
+
+        {{-- Classic script, before the iframe, so the value is in place by the
+             time Plan boots and reads it. Only a locale Plan ships is written,
+             and a failure here just leaves Plan on its own default. --}}
+        <script>
+            (function () {
+                var shipped = ['CN','CS','DE','EN','ES','FI','FR','IT','JA','KO','NL','PT_BR','RU'];
+                var wanted = @json($planLocale);
+                try {
+                    if (shipped.indexOf(wanted) !== -1 && localStorage.getItem('locale') !== wanted) {
+                        localStorage.setItem('locale', wanted);
+                    }
+                } catch (e) { /* storage unavailable, Plan keeps its default */ }
+            })();
+        </script>
+
+        {{-- Plan is a full dashboard in its own right, so this hands it the room
+             and lets it be itself. The section caps its content at screen-lg,
+             which is far too narrow, so this steps outside that and recentres.
+
+             A full 100vh because the navbar is relative rather than sticky, so
+             nothing overlaps it. Scrolled into view it fills the screen, and a
+             px cap would only shrink it on a tall monitor. --}}
+        <div class="relative left-1/2 -translate-x-1/2 overflow-hidden rounded-lg shadow-lg bg-base-200"
+             style="width: 80vw; height: 100vh; min-height: 36rem;">
+            <iframe
+                src="{{ $statsPath }}"
+                title="{{ __('stats.title') }}"
+                loading="lazy"
+                class="absolute inset-0 w-full h-full border-0"
+                allowfullscreen>
+            </iframe>
+        </div>
+
+        <div class="mt-6 text-center">
+            <a href="{{ $statsPath }}" target="_blank" rel="noopener"
+               class="btn btn-primary">{{ __('stats.fullscreen') }}</a>
+        </div>
+
+    </x-section>
+
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,16 @@ Route::get('/vote', function () {
 //     return view('coming-soon');
 // })->name('stats');
 
+// stats
+Route::get('/stats', function () {
+    return view('stats');
+})->name('stats');
+
+// maps
+Route::get('/maps', function () {
+    return view('maps');
+})->name('maps');
+
 // rules
 Route::get('/rules', function () {
     return view('rules');


### PR DESCRIPTION
Both were navbar links that threw you at another domain. They are pages now, each embedding the tool with a link to open it fullscreen.

## The map

Needed nothing clever. BlueMap sets no framing headers, ships its own picker for the 15 maps it serves, and only wanted room.

## The stats

Needed the Caddyfile. Plan picks its language from `localStorage`:

```js
this.clientLocale = window.localStorage.getItem("locale") || this.defaultLanguage;
```

No query parameter, no cookie, no `Accept-Language` — I checked the source, not just the minified bundle. An embedding page on another origin has no way to influence that.

So rather than patching anything inside Plan, **FrankenPHP proxies it from this origin**. The site and dashboard then share `localStorage`, and the language follows the session with nothing modified in Plan.

`docker/Caddyfile` is Octane's own stub with one block added, kept placeholder-for-placeholder so everything Octane injects through the environment still works, passed via the `--caddyfile` option Octane already supports. Caddy proxies in Go — routing a megabyte of dashboard bundle through PHP would be the wrong tool.

Plan's bundle also requests `/static`, `/v1`, `/auth` and `/pageExtensionApi.js` as absolute paths, so those are proxied too. Checked for collisions: the site claims none of them, its assets are under `/build`.

## Verified

Built the image and ran it:

```
/stats/network        200   <title>Plan | Player Analytics</title>
/v1/version           200   {"currentVersion":"5.8 build 3605"}
/pageExtensionApi.js  200
/  /rules  /stats     200   site unaffected
```

Caddy also validated the config directly: `Valid configuration`.

## Note

Both embeds step outside the section, which caps content at `screen-lg` and is far too narrow for either. The stats embed takes the full viewport height, since the navbar is `relative` rather than sticky so nothing overlaps it.

The stats locale files existed but were **0 bytes** — this fills them rather than replacing anything.