### PR TITLE
Point the Plan upstream at the port it actually serves

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -47,23 +47,23 @@
 	# /pageExtensionApi.js as absolute paths, which is why those are proxied
 	# too. The site claims none of them, its own assets are under /build.
 	handle_path /stats/* {
-		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:8804}
 	}
 
 	handle /static/* {
-		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:8804}
 	}
 
 	handle /v1/* {
-		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:8804}
 	}
 
 	handle /auth/* {
-		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:8804}
 	}
 
 	handle /pageExtensionApi.js {
-		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:80}
+		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:8804}
 	}
 
 	route {


### PR DESCRIPTION
The `plan` service is headless (`ClusterIP: None`), so its DNS name resolves straight to the endpoint address and does **no port mapping**. My Caddyfile defaulted to port 80, which reaches nothing — Plan is on 8804.

The ingress works because ingress-nginx reads the Endpoints object directly rather than going through DNS, which is what hid this.

Verified from inside the cluster:

```
plan.plan.svc.cluster.local      -> 000
plan.plan.svc.cluster.local:8804 -> 200
10.0.2.143:8804                  -> 200
```

Using the service name rather than the endpoint IP so it survives that address changing, and defaulting it in the Caddyfile so neither deployment needs `PLAN_UPSTREAM` set.