### PR TITLE
Give every page its own name in the browser tab

### DIFF
--- a/app/Helpers/DiscordHelper.php
+++ b/app/Helpers/DiscordHelper.php
@@ -11,9 +11,18 @@ class DiscordHelper
 
     public static function getPlayersConnected()
     {
+        $endpoint = config('services.discord.json-api');
+
+        // No default for this one, so an install that has not set it would hand
+        // Http::get a null and take the home page down with a TypeError. -1 is
+        // the same "unknown" the header already knows how to hide.
+        if (!$endpoint) {
+            return -1;
+        }
+
         try {
-            $discordInfo = Cache::remember('discord-json-api', config('services.discord-json-api-time'), function () {
-                return Http::get(config('services.discord.json-api'))->json();
+            $discordInfo = Cache::remember('discord-json-api', config('services.discord.json-api-time'), function () use ($endpoint) {
+                return Http::get($endpoint)->json();
             });
         } catch (ConnectionException $e) {
             //TODO Log the error with sentry

--- a/app/Helpers/McHelper.php
+++ b/app/Helpers/McHelper.php
@@ -31,15 +31,27 @@ class McHelper
         return $versions;
     }
 
+    /**
+     * Same contract as getVersions: always an array with a players key. An
+     * empty or non-json body makes ->json() return null, and countPlayers
+     * reads ['players'] straight off it, so anything else here is a 500 on
+     * the home page the moment the api answers with something unexpected.
+     */
     public static function getPlayers()
     {
         try {
-            return Cache::remember('redcraft-bungee-json-api.endpoint.players', config('services.redcraft-bungee-json-api.endpoint.players-time'), function () {
+            $players = Cache::remember('redcraft-bungee-json-api.endpoint.players', config('services.redcraft-bungee-json-api.endpoint.players-time'), function () {
                 return Http::timeout(config('services.redcraft-bungee-json-api.endpoint.timeout'))->get(config('services.redcraft-bungee-json-api.endpoint.players'))->json();
             });
         } catch (ConnectionException $e) {
+            $players = null;
+        }
+
+        if (! is_array($players) || ! array_key_exists('players', $players)) {
             return ['players' => -1];
         }
+
+        return $players;
     }
 
     public static function countPlayersConnected()

--- a/app/View/Components/AppLayout.php
+++ b/app/View/Components/AppLayout.php
@@ -7,6 +7,15 @@ use Illuminate\View\Component;
 class AppLayout extends Component
 {
     /**
+     * @param  string|null  $title  Name of the page, shown before the site name
+     *                              in the browser tab. Null leaves the site name
+     *                              on its own, which is what the home page wants.
+     */
+    public function __construct(public ?string $title = null)
+    {
+    }
+
+    /**
      * Get the view / contents that represents the component.
      *
      * @return \Illuminate\View\View

--- a/app/View/Components/GuestLayout.php
+++ b/app/View/Components/GuestLayout.php
@@ -7,6 +7,14 @@ use Illuminate\View\Component;
 class GuestLayout extends Component
 {
     /**
+     * @param  string|null  $title  Name of the page, shown before the site name
+     *                              in the browser tab.
+     */
+    public function __construct(public ?string $title = null)
+    {
+    }
+
+    /**
      * Get the view / contents that represents the component.
      *
      * @return \Illuminate\View\View

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('about.title') }}">
 
     <x-page-header section-title="{{ __('about.title') }}" />
 

--- a/resources/views/api/index.blade.php
+++ b/resources/views/api/index.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('API Tokens') }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('API Tokens') }}

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Confirm Password') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Reset Password') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Log in') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Register') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Reset Password') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Two-factor Confirmation') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Email Verification') }}">
     <x-authentication-card>
         <x-slot name="logo">
             <x-authentication-card-logo />

--- a/resources/views/coming-soon.blade.php
+++ b/resources/views/coming-soon.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('coming-soon.title') }}">
 
     <x-page-header section-title="{{ __('coming-soon.title') }}" />
 

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('contact.title') }}">
 
     <x-page-header section-title="{{ __('contact.title') }}" />
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('Dashboard') }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Dashboard') }}

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('errors.404.title') }}">
 
     <x-page-header section-title="{{ __('errors.404.title') }}" />
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        {{-- Page name first: a tab strip full of RedCraft tabs is unreadable
+             when the site name leads every one of them. --}}
+        <title>{{ $title ? $title . ' | ' . config('app.name', 'RedCraft') : config('app.name', 'RedCraft') }}</title>
 
         <!-- Fonts -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,7 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        {{-- Page name first: a tab strip full of RedCraft tabs is unreadable
+             when the site name leads every one of them. --}}
+        <title>{{ $title ? $title . ' | ' . config('app.name', 'RedCraft') : config('app.name', 'RedCraft') }}</title>
 
         <!-- Fonts -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">

--- a/resources/views/maps.blade.php
+++ b/resources/views/maps.blade.php
@@ -2,7 +2,7 @@
     $mapUrl = config('services.bluemap-url');
 @endphp
 
-<x-app-layout>
+<x-app-layout title="{{ __('maps.title') }}">
 
     <x-page-header section-title="{{ __('maps.title') }}" />
 

--- a/resources/views/policy.blade.php
+++ b/resources/views/policy.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Privacy Policy') }}">
     <div class="pt-4 bg-gray-100">
         <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
             <div>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('Profile') }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Profile') }}

--- a/resources/views/rules.blade.php
+++ b/resources/views/rules.blade.php
@@ -66,7 +66,7 @@
     ];
 @endphp
 
-<x-app-layout>
+<x-app-layout title="{{ __('rules.title') }}">
 
     <x-page-header section-title="{{ __('rules.title') }}" />
 

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -9,7 +9,7 @@
     $planLocale = strtoupper(app()->getLocale());
 @endphp
 
-<x-app-layout>
+<x-app-layout title="{{ __('stats.title') }}">
 
     <x-page-header section-title="{{ __('stats.title') }}" />
 

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Terms of Service') }}">
     <div class="pt-4 bg-gray-100">
         <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
             <div>

--- a/tests/Feature/PageTitleTest.php
+++ b/tests/Feature/PageTitleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+/**
+ * Every page used to send the bare site name, so a tab strip was a row of
+ * identical RedCraft labels and a bookmark said nothing about its target.
+ */
+class PageTitleTest extends TestCase
+{
+    private function titleOf(TestResponse $response): string
+    {
+        $response->assertOk();
+
+        preg_match('/<title>(.*?)<\/title>/s', $response->getContent(), $matches);
+
+        return trim($matches[1] ?? '');
+    }
+
+    public function test_each_page_sends_its_own_name()
+    {
+        Http::fake();
+
+        $pages = [
+            '/about' => 'About and FAQ',
+            '/contact' => 'Contact Us',
+            '/maps' => 'Maps',
+            '/rules' => 'Rules',
+            '/stats' => 'Stats',
+            '/vote' => 'Coming Soon™',
+        ];
+
+        foreach ($pages as $uri => $name) {
+            $this->assertSame(
+                $name . ' | ' . config('app.name'),
+                $this->titleOf($this->get($uri)),
+                "Wrong title for {$uri}"
+            );
+        }
+    }
+
+    public function test_the_home_page_is_the_site_name_on_its_own()
+    {
+        Http::fake();
+
+        $this->assertSame(
+            config('app.name'),
+            $this->titleOf($this->get('/'))
+        );
+    }
+
+    /**
+     * The cookie has to go in unencrypted. It is in the EncryptCookies except
+     * list, so the middleware hands the raw value straight to LanguageSwitcher.
+     */
+    public function test_the_name_is_translated()
+    {
+        Http::fake();
+
+        $this->assertSame(
+            'Règles | ' . config('app.name'),
+            $this->titleOf($this->withUnencryptedCookie('language', 'fr')->get('/rules'))
+        );
+    }
+}


### PR DESCRIPTION
Every page sent `<title>RedCraft</title>`, so a tab strip was a row of identical labels and a bookmark said nothing about its target. `git log -L8,8` on both layouts shows one commit touching that line, the initial one, so this is a gap rather than something the FrankenPHP migration dropped.

Both layouts are class components, so the name arrives through the constructor rather than `@props`. Nineteen views pass one, all from translation keys the lang files already carried, so French needed no new strings. Home passes nothing on purpose and keeps the site name alone.

Format is `Rules | RedCraft`, page name first, since the site name leading all of them is what made the tab strip useless in the first place.

### The two helper fixes

They are here because `PageTitleTest` cannot go green without them. Asserting the home page returns 200 was enough to surface both:

- `McHelper::getPlayers()` returned whatever `->json()` gave it, which is null for an empty or non-json body, and `countPlayersConnected()` reads `['players']` straight off that. `getVersions()` was already hardened against exactly this; `getPlayers()` had been missed.
- `DiscordHelper` read `services.discord-json-api-time`, a key that does not exist. The lookup returned null, and a null ttl makes `Cache::remember` store **forever**, so the player count was cached for the life of the process rather than the intended 15 seconds. It also passed a possibly null endpoint into `Http::get`.

Live config sets both env vars so production was not hitting the crash, but any fresh checkout was.

### Checks

`PageTitleTest` is 3 tests, 16 assertions. I reverted the layout to the old static title and confirmed 2 of the 3 fail before restoring it, so it is a real regression guard rather than a tautology. The DB-backed suite does not run locally here (no sqlite driver, no MySQL up), so CI covers that half.
