### PR TITLE
Let Plan reach its own api once it knows its base path

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -47,6 +47,13 @@
 	# /pageExtensionApi.js as absolute paths, which is why those are proxied
 	# too. The site claims none of them, its own assets are under /build.
 	handle_path /stats/* {
+		# Plan derives its API base from Webserver.Alternative_IP and always
+		# prefixes it with its own protocol, which is http since TLS terminates
+		# out here rather than inside Plan. This page is served over https, so
+		# those XHRs would be refused as mixed content. Upgrading them is much
+		# cheaper than running a keystore inside the plugin.
+		header Content-Security-Policy "upgrade-insecure-requests"
+
 		reverse_proxy {$PLAN_UPSTREAM:plan.plan.svc.cluster.local:8804}
 	}
 


### PR DESCRIPTION
Second half of the `/stats/network` 404. **Do not merge until the server side lands**, though it is harmless either way.

### What was actually wrong

`getAccessAddress()` never reads `External_Webserver_address`. That key is `EXTERNAL_LINK`, used only as a fallback when the webserver is disabled outright. The real feed is `Webserver.Alternative_IP.Address`, still set to `minecraft.redcraft.org:%port%`:

```java
return getIP().map(ip -> webServer.getProtocol() + "://" + ip);   // Addresses.java:84
```

So the substitution was happening the whole time. I had been grepping the main `index-*.js`; the value lives in `authenticationHook-*.js` as ``address:`http://minecraft.redcraft.org:8804` ``. Since that does not prefix `window.location.href`, the frontend blanks `baseAddress`, the router basename becomes `""`, and `/stats/network` resolves to nothing. Plan even logs the reason and names the setting to change.

### Why this header

`isCurrentAddress` strips both protocols before comparing, so `http://redcraft.org/stats` matches an `https://` page fine. But `baseAddress` is *also* used verbatim as the XHR prefix, so every api call would go out as `http://` from an `https://` document and get blocked as mixed content. `upgrade-insecure-requests` fixes that without a keystore inside the plugin, and no jar patching.

### Server side, still outstanding

```
Webserver:
  Alternative_IP:
    Address: redcraft.org/stats
```

then reload Plan. I could not apply it from here.

### Checks

`frankenphp validate --adapter caddyfile` against `dunglas/frankenphp:1.12-php8.5-trixie` reports `Valid configuration`. No behaviour change today: with the address blank the frontend already requests relative paths, so there are no http subresources for the header to act on.
